### PR TITLE
ci: Use up to date actions, build against multiple ghidra versions.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,22 +15,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-extension:
-
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    strategy:
+      matrix:
+        ghidra:
+          - "11.2.1"
+          - "11.2"
+          - "11.1.2"
+          - "11.1.1"
+          - "11.1"
+          - "11.0.3"
+          - "11.0.2"
+          - "11.0.1"
+          - "11.0"
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup JDK
       uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
-    - uses: er28-0652/setup-ghidra@master
+
+    - name: Setup Ghidra
+      uses: antoniovazquezblanco/setup-ghidra@v2.0.6
       with:
-        version: "11.2"
+        version: ${{ matrix.ghidra }}
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
@@ -43,13 +58,25 @@ jobs:
       run: gradle buildExtension
       working-directory: ./GhidraR2Web
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: GhidraR2Web_Ghidra_${{ matrix.ghidra }}
+        path: GhidraR2Web/dist/*.zip
+
+  release:
+    runs-on: "ubuntu-latest"
+    needs: build
+
+    steps:
+    - name: Download binaries
+      uses: actions/download-artifact@v4
+
     - name: Release 
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          GhidraR2Web/dist/*.zip
+          GhidraR2Web_Ghidra_*/*.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: None
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Minor CI improvements. Mostly, you were using an obsolete github action. I happen to maintain a similar action because the previous one was abandoned.

I also wanted to try and provide builds for different ghidra versions because Ghidra is sometimes picky with installing plugins for other versions. Please, feel free to ask me to add or remove other versions.

**To be done**
If you want to further improve this I would recommend to always build (for pr testing) and only release on tag creation but I did not want to change your "release" policy without you confirming if you really want this. Please, let me know if you want me to do that.

Thanks!
